### PR TITLE
[[7480]] add right click menu to swap versions from cuts tray

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 # Metadata defining the behaviour and requirements for this engine
@@ -13,14 +13,14 @@
 # expected fields in the configuration file for this engine
 configuration:
 
-# this app works in all engines - it does not contain 
+# this app works in all engines - it does not contain
 # any host application specific commands
-supported_engines: 
+supported_engines:
 
 # the Shotgun fields that this engine needs in order to operate correctly
 requires_shotgun_fields:
-        
-# More verbose description of this item 
+
+# More verbose description of this item
 display_name: "Shotgun Review for RV"
 description: "Provides access to Cuts, Versions, and Notes in RV."
 

--- a/python/tk_rv_shotgunreview/popup_utils.py
+++ b/python/tk_rv_shotgunreview/popup_utils.py
@@ -107,6 +107,25 @@ class PopupUtils(QtCore.QObject):
     #     self._preset_pipeline = True
     #     self.check_pipeline_menu()
 
+    def refresh_version_search_menu(self):
+        """
+        Refresh the contents of the VersionSearchMenu in the cuts tray,
+        so that it only displays Versions from the source that is
+        currently being viewed.
+        """
+
+        version = self._rv_mode.version_data_from_source()
+
+        # shouldn't happen, but just in case, skip updating the version
+        # search menu
+        if not version.get('entity'):
+            return
+
+        filters = [['project', 'is', self._project_entity],
+                   ['entity', 'is', version.get('entity')]]
+
+        self._tray_frame.version_search_menu.load(version, filters)
+
     def find_rel_cuts_with_model(self, entity_in, shot_entity=None):
         """
         This initiates two queries, one for all related cuts, and the other

--- a/python/tk_rv_shotgunreview/tray_main_frame.py
+++ b/python/tk_rv_shotgunreview/tray_main_frame.py
@@ -297,13 +297,13 @@ class TrayMainFrame(QtGui.QFrame):
         # the end of the widget and the screen border)
         if proposed_max_y > self._screen_height:
             y_offset = proposed_max_y - self._screen_height
-            y = (curr_y - y_offset) + 10
+            y = (curr_y - y_offset) - 10
         else:
             y = curr_y
 
         if proposed_max_x > self._screen_width:
             x_offset = proposed_max_x - self._screen_width
-            x = (curr_x - x_offset) + 10
+            x = (curr_x - x_offset) - 10
         else:
             x = curr_x
 

--- a/python/tk_rv_shotgunreview/tray_main_frame.py
+++ b/python/tk_rv_shotgunreview/tray_main_frame.py
@@ -1,16 +1,17 @@
 # Copyright (c) 2016 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from tank.platform.qt import QtCore, QtGui
 from .tray_delegate import RvTrayDelegate
 from .mini_cut_widget import MiniCutWidget
+from .tray_version_search import VersionSearchMenu
 
 import os
 import tank
@@ -31,6 +32,7 @@ class TrayMainFrame(QtGui.QFrame):
         self.tray_list = None
         self.tray_delegate = None
         self.tray_proxyModel = None
+        self.tray_version_search = None
 
         self._rv_mode = rv_mode
         # using the new singleton bg manager
@@ -83,7 +85,7 @@ class TrayMainFrame(QtGui.QFrame):
         self.tray_button_bar_grid.setContentsMargins(0, 0, 0, 0)
         self.tray_button_bar_grid.setHorizontalSpacing(8)
         self.tray_button_bar_grid.setVerticalSpacing(0)
-        
+
         self.tray_button_bar.setObjectName('tray_button_bar')
         sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(1)
@@ -95,7 +97,7 @@ class TrayMainFrame(QtGui.QFrame):
         self.tray_button_bar_hlayout.setSpacing(16)
         self.tray_button_bar_grid.addLayout(self.tray_button_bar_hlayout, 0, 0)
         self.tray_button_bar_hlayout.setContentsMargins(0, 0, 0, 0)
-        
+
         self.tray_button_browse_cut = QtGui.QPushButton()
         self.tray_button_browse_cut.setText('Cut Name')
         self.tray_button_bar_hlayout.addWidget(self.tray_button_browse_cut)
@@ -122,7 +124,7 @@ class TrayMainFrame(QtGui.QFrame):
         icon = QtGui.QIcon(f)
         self.tray_mini_label.setIcon(icon)
 
-        self.tray_button_bar_hlayout.addWidget(self.tray_mini_label) 
+        self.tray_button_bar_hlayout.addWidget(self.tray_mini_label)
         self.tray_button_bar_hlayout.addStretch(1)
 
         self.pipeline_filter_button = QtGui.QPushButton()
@@ -222,15 +224,15 @@ class TrayMainFrame(QtGui.QFrame):
 
         self.tray_frame_vlayout.addWidget(self.tray_button_bar)
         self.tray_frame_vlayout.setStretchFactor(self.tray_button_bar, 1)
-        
+
         # QListView ##########################
         #####################################################################
         self.tray_list = QtGui.QListView()
         self.tray_list.rv_mode = self._rv_mode
         self.tray_list.setFocusPolicy(QtCore.Qt.NoFocus)
-                
+
         self.tray_frame_vlayout.addWidget(self.tray_list)
-        
+
         from .tray_model import TrayModel
         self.tray_model = TrayModel(self.tray_list, bg_task_manager=self._task_manager, engine=self._rv_mode._app.engine)
 
@@ -247,15 +249,26 @@ class TrayMainFrame(QtGui.QFrame):
         self.tray_list.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self.tray_list.setFlow(QtGui.QListView.LeftToRight)
         self.tray_list.setUniformItemSizes(True)
-                
+
         self.tray_list.setObjectName("tray_list")
 
         self.mc_widget = MiniCutWidget(self)
         self.mc_widget.setVisible(False)
         self.tray_dock.mc_widget = self.mc_widget
-        # mc_widget can change its parent when undocked, so we need to store a reference to 
+        # mc_widget can change its parent when undocked, so we need to store a reference to
         # tray_dock so we dont have to rely on parent exclusively.
         self.mc_widget.tray_dock = self.tray_dock
-       
 
+        self.tray_list.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.tray_list.customContextMenuRequested.connect(self._show_version_search)
 
+        self.version_search_menu = VersionSearchMenu(self)
+
+        # not totally sure what style sheet this widget is inheriting from,
+        # so force the item colors here (otherwise the child items appear the
+        # same color as the widget's background, making them impossible to read)
+        self.version_search_menu.setStyleSheet("QTreeView { color: rgb(125, 126, 127) } "
+                                               "QTreeView::item {color: rgb(125, 126, 127) }")
+
+    def _show_version_search(self, q_point):
+        self.version_search_menu.exec_(QtGui.QCursor.pos())

--- a/python/tk_rv_shotgunreview/tray_main_frame.py
+++ b/python/tk_rv_shotgunreview/tray_main_frame.py
@@ -270,5 +270,42 @@ class TrayMainFrame(QtGui.QFrame):
         self.version_search_menu.setStyleSheet("QTreeView { color: rgb(125, 126, 127) } "
                                                "QTreeView::item {color: rgb(125, 126, 127) }")
 
+        # utilized by _show_version_search() to offset QCursor.pos so we can
+        # ensure the whole version search menu appears where the user can
+        # see it
+        desktop = QtGui.QDesktopWidget()
+        self._screen_height = desktop.height()
+        self._screen_width = desktop.width()
+
     def _show_version_search(self, q_point):
-        self.version_search_menu.exec_(QtGui.QCursor.pos())
+
+        current_cursor_pos = QtGui.QCursor.pos()
+
+        curr_y = current_cursor_pos.y()
+        curr_x = current_cursor_pos.x()
+
+        # propsed y and x max represent the bottom corners of the menu
+        # as it would be drawn; we'll check these coordinates against the
+        # current screen size + cursor position to ensure that the menu
+        # won't be partially drawn off screen
+        proposed_max_y = curr_y + 500
+        proposed_max_x = curr_x + 500
+
+        # if either proposed coordinate is past the bottom or right hand
+        # side of the screen, then offset it by the difference between the
+        # screen edge and the end of the widget (leaving a few pixels between
+        # the end of the widget and the screen border)
+        if proposed_max_y > self._screen_height:
+            y_offset = proposed_max_y - self._screen_height
+            y = (curr_y - y_offset) + 10
+        else:
+            y = curr_y
+
+        if proposed_max_x > self._screen_width:
+            x_offset = proposed_max_x - self._screen_width
+            x = (curr_x - x_offset) + 10
+        else:
+            x = curr_x
+
+        menu_pos = QtCore.QPoint(x, y)
+        self.version_search_menu.exec_(menu_pos)

--- a/python/tk_rv_shotgunreview/tray_version_search.py
+++ b/python/tk_rv_shotgunreview/tray_version_search.py
@@ -46,7 +46,8 @@ class VersionSearchMenu(QtGui.QMenu):
               'sg_movie_has_slate',
               'entity']
 
-    FILTERS = ['sg_path_to_movie', 'is_not', None]
+    FILTERS = [['sg_path_to_movie', 'is_not', None],
+               ['sg_step.Step.sg_hide_from_sg_review', 'is_not', True]]
 
     def __init__(self, parent=None, engine=None):
         QtGui.QMenu.__init__(self, parent)
@@ -55,10 +56,9 @@ class VersionSearchMenu(QtGui.QMenu):
         self._connect_signals()
 
     def _init_ui(self):
-
-        self._main_layout = QtGui.QVBoxLayout(self)
-        self._search_layout = QtGui.QHBoxLayout(self)
-        self._version_layout = QtGui.QHBoxLayout(self)
+        self._main_layout = QtGui.QVBoxLayout()
+        self._search_layout = QtGui.QHBoxLayout()
+        self._version_layout = QtGui.QHBoxLayout()
 
         self._search_widget = search_widget.SearchWidget(self)
         self._search_layout.addWidget(self._search_widget)
@@ -83,14 +83,11 @@ class VersionSearchMenu(QtGui.QMenu):
         self.setMinimumHeight(500)
 
         '''
-        TODO:
-        - Automatically expand all tree contents when data reloads?
+        Maybe #TODO pending user feedback:
+        - Automatically expand all tree contents when data reloads
         - Set menu size based on model contents
         - Do we need to deal with users wanting sg_frames instead of sg_path_to_movie?
         - When searching via proxy, hide tree items that have no children
-        - Figure out what's generating the 'layout already set' errors
-        - Reverse order of versions in UI, hide same steps that pipeline step
-          dropdown is hiding
         '''
 
     def _connect_signals(self):
@@ -111,6 +108,9 @@ class VersionSearchMenu(QtGui.QMenu):
         item = self.version_model.itemFromIndex(self._version_proxy.mapToSource(event))
         sg_data = item.get_sg_data()
 
+        if not sg_data:
+            return
+
         # since this is only being used in tk-rv-shotgunreview, we want to leverage
         # that plugin's existing _swap_into_sequence, which expects to receive
         # a list of versions; so we'll emit a list, even though we only have one
@@ -127,7 +127,7 @@ class VersionSearchMenu(QtGui.QMenu):
             model only loads versions from the correct show/entity.
         """
 
-        version_filters = filters.append(self.FILTERS)
+        version_filters = filters.extend(self.FILTERS)
 
         self.version_model._load_data('Version',
                                       filters,
@@ -138,3 +138,4 @@ class VersionSearchMenu(QtGui.QMenu):
 
         self._version_proxy.invalidateFilter()
         self._version_proxy.setFilterWildcard('*')
+        self._version_proxy.sort(0, QtCore.Qt.DescendingOrder)

--- a/python/tk_rv_shotgunreview/tray_version_search.py
+++ b/python/tk_rv_shotgunreview/tray_version_search.py
@@ -86,9 +86,11 @@ class VersionSearchMenu(QtGui.QMenu):
         TODO:
         - Automatically expand all tree contents when data reloads?
         - Set menu size based on model contents
-        - Offset menu position when in fullscreen, so menu isn't lost off screen
         - Do we need to deal with users wanting sg_frames instead of sg_path_to_movie?
         - When searching via proxy, hide tree items that have no children
+        - Figure out what's generating the 'layout already set' errors
+        - Reverse order of versions in UI, hide same steps that pipeline step
+          dropdown is hiding
         '''
 
     def _connect_signals(self):

--- a/python/tk_rv_shotgunreview/tray_version_search.py
+++ b/python/tk_rv_shotgunreview/tray_version_search.py
@@ -1,0 +1,138 @@
+
+import sgtk
+
+from sgtk.platform.qt import QtCore, QtGui
+
+shotgun_model = sgtk.platform.import_framework(
+    "tk-framework-shotgunutils",
+    "shotgun_model",
+)
+
+proxy_models = sgtk.platform.import_framework(
+    "tk-framework-qtwidgets",
+    "models",
+)
+
+search_widget = sgtk.platform.import_framework(
+    "tk-framework-qtwidgets",
+    "search_widget",
+)
+
+hierarchical_proxy = proxy_models.hierarchical_filtering_proxy_model
+
+class VersionTreeProxyModel(hierarchical_proxy.HierarchicalFilteringProxyModel):
+
+    def __init__(self, parent=None):
+        super(VersionTreeProxyModel, self).__init__(parent=parent)
+
+    def _is_row_accepted(self, src_row, src_parent_idx, parent_accepted):
+
+        if not parent_accepted:
+            return True
+
+        model = self.sourceModel()
+
+        version_code = model.data(model.index(src_row, 0, src_parent_idx))
+        code_matches = self.filterRegExp().exactMatch(version_code)
+
+        return code_matches
+
+class VersionSearchMenu(QtGui.QMenu):
+
+    version_selected = QtCore.Signal(list)
+
+    FIELDS = ['sg_uploaded_movie_frame_rate',
+              'sg_first_frame',
+              'sg_movie_has_slate',
+              'entity']
+
+    FILTERS = ['sg_path_to_movie', 'is_not', None]
+
+    def __init__(self, parent=None, engine=None):
+        QtGui.QMenu.__init__(self, parent)
+
+        self._init_ui()
+        self._connect_signals()
+
+    def _init_ui(self):
+
+        self._main_layout = QtGui.QVBoxLayout(self)
+        self._search_layout = QtGui.QHBoxLayout(self)
+        self._version_layout = QtGui.QHBoxLayout(self)
+
+        self._search_widget = search_widget.SearchWidget(self)
+        self._search_layout.addWidget(self._search_widget)
+
+        self._version_view = QtGui.QTreeView(self)
+        self._version_proxy = VersionTreeProxyModel(self._version_view)
+        self.version_model = shotgun_model.ShotgunModel(self._version_view,
+                                                        download_thumbs=False,
+                                                        bg_load_thumbs=False)
+
+        self._version_proxy.setFilterWildcard('*')
+        self._version_proxy.setSourceModel(self.version_model)
+        self._version_view.setModel(self._version_proxy)
+        self._version_layout.addWidget(self._version_view)
+
+        self._main_layout.addLayout(self._search_layout)
+        self._main_layout.addLayout(self._version_layout)
+
+        self.setLayout(self._main_layout)
+
+        self.setMinimumWidth(500)
+        self.setMinimumHeight(500)
+
+        '''
+        TODO:
+        - Automatically expand all tree contents when data reloads?
+        - Set menu size based on model contents
+        - Offset menu position when in fullscreen, so menu isn't lost off screen
+        - Do we need to deal with users wanting sg_frames instead of sg_path_to_movie?
+        - When searching via proxy, hide tree items that have no children
+        '''
+
+    def _connect_signals(self):
+        # tell the proxy to update its search as the user types and whenever
+        # the user hits 'enter'
+        self._search_widget.search_edited.connect(self._set_proxy_regex)
+        self._search_widget.search_changed.connect(self._set_proxy_regex)
+
+        self._version_view.doubleClicked.connect(self._version_selected)
+
+    def _set_proxy_regex(self, search_args):
+        self._version_proxy.invalidateFilter()
+        regex = '*{args}*'.format(args=search_args)
+        self._version_proxy.setFilterWildcard(regex)
+        self._version_proxy.invalidateFilter()
+
+    def _version_selected(self, event):
+        item = self.version_model.itemFromIndex(self._version_proxy.mapToSource(event))
+        sg_data = item.get_sg_data()
+
+        # since this is only being used in tk-rv-shotgunreview, we want to leverage
+        # that plugin's existing _swap_into_sequence, which expects to receive
+        # a list of versions; so we'll emit a list, even though we only have one
+        # version to swap in
+        self.version_selected.emit([sg_data])
+
+    def load(self, version, filters):
+        """
+        Given a version, load associated versions into the VersionSearchMenu.
+
+        :param version dict: Version entity to find associated Versions for.
+        :param filters list: List of Shotgun query filters. Typically this
+            should contain the version's project and entity, so that the
+            model only loads versions from the correct show/entity.
+        """
+
+        version_filters = filters.append(self.FILTERS)
+
+        self.version_model._load_data('Version',
+                                      filters,
+                                      ['sg_step', 'code'],
+                                      self.FIELDS)
+
+        self.version_model._refresh_data()
+
+        self._version_proxy.invalidateFilter()
+        self._version_proxy.setFilterWildcard('*')


### PR DESCRIPTION
First pass at a right click menu to allow swapping in versions from the SG Review cut tray. Still need to hit some of the TODOs noted in tray_version_search.py (particularly the one where the menu is cut off when RV is full screen; I imagine people are going to notice/complain about that pretty quickly.)